### PR TITLE
do not wait for termination of previous processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.1-alpine3.21 as builder
+FROM golang:1.24.10-alpine3.21 as builder
 ARG VERSION
 ARG HASH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.10-alpine3.21 as builder
+FROM golang:1.25.5-alpine3.23 as builder
 ARG VERSION
 ARG HASH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine3.23 as builder
+FROM golang:1.25.5-alpine3.23 AS builder
 ARG VERSION
 ARG HASH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snorwin/haproxy-reload-wrapper
 
-go 1.24.1
+go 1.24.10
 
 require github.com/fsnotify/fsnotify v1.9.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snorwin/haproxy-reload-wrapper
 
-go 1.24.10
+go 1.25.5
 
 require github.com/fsnotify/fsnotify v1.9.0
 

--- a/main.go
+++ b/main.go
@@ -94,7 +94,7 @@ func main() {
 			}
 
 			cmd = tmp
-			log.Notice(fmt.Sprintf("process %d started", tmp.Process.Pid))
+			log.Notice(fmt.Sprintf("started process with pid %d and status %s", tmp.Process.Pid, tmp.Status()))
 		case err := <-fswatch.Errors:
 			// handle errors of fsnotify.Watcher
 			log.Alert(err.Error())

--- a/main.go
+++ b/main.go
@@ -92,6 +92,11 @@ func main() {
 				log.Warning("reload failed")
 				continue
 			}
+			go func() {
+				 <-cmd.Terminated
+				log.Notice(fmt.Sprintf("process %d terminated : %s", cmd.Process.Pid, cmd.Status()))
+				log.Notice("reload successful")
+			}()
 
 			cmd = tmp
 			log.Notice(fmt.Sprintf("started process with pid %d and status %s", tmp.Process.Pid, tmp.Status()))

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 				log.Warning("reload failed")
 				continue
 			}
-			go func(cmd exec.Cmd) {
+			go func(cmd *exec.Cmd) {
 				 <-cmd.Terminated
 				log.Notice(fmt.Sprintf("process %d terminated : %s", cmd.Process.Pid, cmd.Status()))
 				log.Notice("reload successful")

--- a/main.go
+++ b/main.go
@@ -92,11 +92,11 @@ func main() {
 				log.Warning("reload failed")
 				continue
 			}
-			go func() {
+			go func(cmd exec.Cmd) {
 				 <-cmd.Terminated
 				log.Notice(fmt.Sprintf("process %d terminated : %s", cmd.Process.Pid, cmd.Status()))
 				log.Notice("reload successful")
-			}()
+			}(cmd)
 
 			cmd = tmp
 			log.Notice(fmt.Sprintf("started process with pid %d and status %s", tmp.Process.Pid, tmp.Status()))


### PR DESCRIPTION
with this change, we want to achieve better handling of long running connections.

we do not need to wait for previous processes to terminate since it's not relevant. the new process will take over listener sockets and serve all new connections while the old processes keep serving the existing, long-running connections. eventually they will terminate by their "hard-stop-after" setting or by another mechanism that is not part of this project here.